### PR TITLE
신고 서비스 레이어의 하위 서비스에 대한 테스트 코드 작성 및 신고 관련 api 에러 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation 'org.mockito:mockito-inline:3.6.0'
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 }

--- a/src/main/java/com/example/unknowngserver/UnknowngServerApplication.java
+++ b/src/main/java/com/example/unknowngserver/UnknowngServerApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+@SpringBootApplication
 public class UnknowngServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/unknowngserver/article/controller/ArticleController.java
+++ b/src/main/java/com/example/unknowngserver/article/controller/ArticleController.java
@@ -30,7 +30,7 @@ public class ArticleController {
         return ResponseEntity.ok(articleDetailInfo);
     }
 
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<List<ArticleBoardInfo>> getArticles(@ModelAttribute PageNumber page,
                                                               @ModelAttribute Keyword keyword) {
 
@@ -43,7 +43,7 @@ public class ArticleController {
         return ResponseEntity.ok(articleBoardInfoList);
     }
 
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<SubmitArticleResponse> submitArticle(@RequestBody @Valid SubmitArticleRequest submitArticleRequest) {
 
         ArticleDto articleDto = articleService.createArticle(submitArticleRequest);
@@ -53,7 +53,7 @@ public class ArticleController {
         return ResponseEntity.ok(submitArticleResponse);
     }
 
-    @DeleteMapping()
+    @DeleteMapping
     public ResponseEntity<Response> deleteArticle(@RequestBody @Valid DeleteArticleRequest deleteArticleRequest) {
 
         articleService.deleteArticle(deleteArticleRequest);

--- a/src/main/java/com/example/unknowngserver/article/controller/ArticleController.java
+++ b/src/main/java/com/example/unknowngserver/article/controller/ArticleController.java
@@ -2,6 +2,9 @@ package com.example.unknowngserver.article.controller;
 
 import com.example.unknowngserver.article.dto.*;
 import com.example.unknowngserver.article.service.ArticleService;
+import com.example.unknowngserver.common.dto.Keyword;
+import com.example.unknowngserver.common.dto.PageNumber;
+import com.example.unknowngserver.common.dto.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,44 +15,49 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/articles")
 public class ArticleController {
 
     private final ArticleService articleService;
 
-    @GetMapping("/articles/{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<ArticleDetailInfo> getArticle(@PathVariable("id") Long id) {
 
         ArticleDto articleDto = articleService.getArticle(id);
 
-        return ResponseEntity.ok(ArticleDetailInfo.fromArticleDto(articleDto));
+        ArticleDetailInfo articleDetailInfo = ArticleDetailInfo.fromArticleDto(articleDto);
+
+        return ResponseEntity.ok(articleDetailInfo);
     }
 
-    @GetMapping("/articles")
-    public ResponseEntity<List<ArticleBoardInfo>> getArticles(@RequestParam(defaultValue = "1", required = false) Integer page,
-                                                              @RequestParam(defaultValue = "", required = false) String keyword) {
-
-        page = (page < 1) ? 1 : page;
+    @GetMapping()
+    public ResponseEntity<List<ArticleBoardInfo>> getArticles(@ModelAttribute PageNumber page,
+                                                              @ModelAttribute Keyword keyword) {
 
         List<ArticleDto> articleDtoList = articleService.getArticles(page, keyword);
 
-        return ResponseEntity.ok(articleDtoList.stream()
+        List<ArticleBoardInfo> articleBoardInfoList = articleDtoList.stream()
                 .map(ArticleBoardInfo::fromArticleDto)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(articleBoardInfoList);
     }
 
-    @PostMapping("/articles")
-    public ResponseEntity<SubmitArticleResponse> submitArticle(
-            @RequestBody @Valid SubmitArticleRequest submitArticleRequest) {
+    @PostMapping()
+    public ResponseEntity<SubmitArticleResponse> submitArticle(@RequestBody @Valid SubmitArticleRequest submitArticleRequest) {
 
         ArticleDto articleDto = articleService.createArticle(submitArticleRequest);
 
-        return ResponseEntity.ok(SubmitArticleResponse.fromArticleDto(articleDto));
+        SubmitArticleResponse submitArticleResponse = SubmitArticleResponse.fromArticleDto(articleDto);
+
+        return ResponseEntity.ok(submitArticleResponse);
     }
 
-    @DeleteMapping("/articles")
-    public ResponseEntity<Boolean> deleteArticle(
-            @RequestBody @Valid DeleteArticleRequest deleteArticleRequest) {
+    @DeleteMapping()
+    public ResponseEntity<Response> deleteArticle(@RequestBody @Valid DeleteArticleRequest deleteArticleRequest) {
 
-        return ResponseEntity.ok(articleService.deleteArticle(deleteArticleRequest));
+        articleService.deleteArticle(deleteArticleRequest);
+
+        return ResponseEntity.ok().body(Response.ok());
     }
 }

--- a/src/main/java/com/example/unknowngserver/article/dto/ArticleBoardInfo.java
+++ b/src/main/java/com/example/unknowngserver/article/dto/ArticleBoardInfo.java
@@ -9,13 +9,19 @@ import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class ArticleBoardInfo {
     private Long id;
     private String author;
     private String title;
     private LocalDate createDate;
+
+    @Builder
+    public ArticleBoardInfo(Long id, String author, String title, LocalDate createDate) {
+        this.id = id;
+        this.author = author;
+        this.title = title;
+        this.createDate = createDate;
+    }
 
     public static ArticleBoardInfo fromArticleDto(ArticleDto articleDto) {
         return ArticleBoardInfo.builder()

--- a/src/main/java/com/example/unknowngserver/article/dto/ArticleDetailInfo.java
+++ b/src/main/java/com/example/unknowngserver/article/dto/ArticleDetailInfo.java
@@ -8,8 +8,6 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Getter
 public class ArticleDetailInfo {
     private Long id;
@@ -17,6 +15,15 @@ public class ArticleDetailInfo {
     private String title;
     private String content;
     private LocalDate createDate;
+
+    @Builder
+    public ArticleDetailInfo(Long id, String author, String title, String content, LocalDate createDate) {
+        this.id = id;
+        this.author = author;
+        this.title = title;
+        this.content = content;
+        this.createDate = createDate;
+    }
 
     public static ArticleDetailInfo fromArticleDto(ArticleDto articleDto) {
         return ArticleDetailInfo.builder()

--- a/src/main/java/com/example/unknowngserver/article/dto/ArticleDto.java
+++ b/src/main/java/com/example/unknowngserver/article/dto/ArticleDto.java
@@ -5,14 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
 import java.time.LocalDateTime;
 
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Getter
 public class ArticleDto {
     private Long id;
@@ -21,7 +17,16 @@ public class ArticleDto {
     private String author;
     private LocalDateTime registeredAt;
 
-    public static ArticleDto fromEntity(Article article) {
+    @Builder
+    public ArticleDto(Long id, String title, String content, String author, LocalDateTime registeredAt) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.registeredAt = registeredAt;
+    }
+
+    public static ArticleDto fromArticle(Article article) {
         return ArticleDto.builder()
                 .id(article.getId())
                 .title(article.getTitle())

--- a/src/main/java/com/example/unknowngserver/article/dto/SubmitArticleRequest.java
+++ b/src/main/java/com/example/unknowngserver/article/dto/SubmitArticleRequest.java
@@ -16,25 +16,4 @@ public class SubmitArticleRequest {
     private String content;
     private String author;
     private String password;
-
-    /*@Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class ServiceDto {
-        private String title;
-        private String article;
-        private String author;
-        private String password;
-    }
-
-
-    public static ServiceDto toServiceDto(SubmitArticleRequest submitArticleRequest) {
-        return ServiceDto.builder()
-                .title(submitArticleRequest.getTitle())
-                .article(submitArticleRequest.getArticle())
-                .author(submitArticleRequest.getAuthor())
-                .password(submitArticleRequest.getPassword())
-                .build();
-    }*/
 }

--- a/src/main/java/com/example/unknowngserver/article/dto/SubmitArticleResponse.java
+++ b/src/main/java/com/example/unknowngserver/article/dto/SubmitArticleResponse.java
@@ -1,19 +1,19 @@
 package com.example.unknowngserver.article.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class SubmitArticleResponse {
 
     private Long articleId;
+
+    @Builder
+    public SubmitArticleResponse(Long articleId) {
+        this.articleId = articleId;
+    }
 
     public static SubmitArticleResponse fromArticleDto(ArticleDto articleDto) {
         return SubmitArticleResponse.builder()

--- a/src/main/java/com/example/unknowngserver/article/dto/SubmitArticleResponse.java
+++ b/src/main/java/com/example/unknowngserver/article/dto/SubmitArticleResponse.java
@@ -1,6 +1,5 @@
 package com.example.unknowngserver.article.dto;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,14 +9,11 @@ public class SubmitArticleResponse {
 
     private Long articleId;
 
-    @Builder
     public SubmitArticleResponse(Long articleId) {
         this.articleId = articleId;
     }
 
     public static SubmitArticleResponse fromArticleDto(ArticleDto articleDto) {
-        return SubmitArticleResponse.builder()
-                .articleId(articleDto.getId())
-                .build();
+        return new SubmitArticleResponse(articleDto.getId());
     }
 }

--- a/src/main/java/com/example/unknowngserver/article/entity/Article.java
+++ b/src/main/java/com/example/unknowngserver/article/entity/Article.java
@@ -1,6 +1,5 @@
 package com.example.unknowngserver.article.entity;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,8 +12,6 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Getter
 @Entity
 @SQLDelete(sql = "UPDATE article SET deleted = true, deleted_at = current_timestamp WHERE id = ?")
@@ -30,8 +27,18 @@ public class Article {
     private String password;
     @CreatedDate
     private LocalDateTime registeredAt;
-
-    @Builder.Default
-    private boolean deleted = false;
+    private boolean deleted;
     private LocalDateTime deletedAt;
+
+    @Builder
+    public Article(Long id, String title, String content, String author, String password, LocalDateTime registeredAt, boolean deleted, LocalDateTime deletedAt) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.password = password;
+        this.registeredAt = registeredAt;
+        this.deleted = deleted;
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/com/example/unknowngserver/comment/controller/CommentController.java
+++ b/src/main/java/com/example/unknowngserver/comment/controller/CommentController.java
@@ -5,6 +5,8 @@ import com.example.unknowngserver.comment.dto.CommentInfo;
 import com.example.unknowngserver.comment.dto.DeleteCommentRequest;
 import com.example.unknowngserver.comment.dto.SubmitCommentRequest;
 import com.example.unknowngserver.comment.service.CommentService;
+import com.example.unknowngserver.common.dto.PageNumber;
+import com.example.unknowngserver.common.dto.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,28 +23,30 @@ public class CommentController {
 
     @GetMapping("/articles/{articleId}/comments")
     public ResponseEntity<List<CommentInfo>> getComments(@PathVariable("articleId") Long articleId,
-                                                         @RequestParam(defaultValue = "1", required = false) Integer page) {
-
-        page = (page < 1) ? 1 : page;
+                                                         @ModelAttribute PageNumber page) {
 
         List<CommentDto> commentDtoList = commentService.getComments(articleId, page);
 
-        return ResponseEntity.ok(commentDtoList.stream()
+        List<CommentInfo> commentInfoList = commentDtoList.stream()
                 .map(CommentInfo::fromCommentDto)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(commentInfoList);
     }
 
     @PostMapping("/comments")
-    public ResponseEntity<Boolean> submitComments(
-            @RequestBody @Valid SubmitCommentRequest submitCommentRequest) {
+    public ResponseEntity<Response> submitComments(@RequestBody @Valid SubmitCommentRequest submitCommentRequest) {
 
-        return ResponseEntity.ok(commentService.createComment(submitCommentRequest));
+        commentService.createComment(submitCommentRequest);
+
+        return ResponseEntity.ok().body(Response.ok());
     }
 
     @DeleteMapping("/comments")
-    public ResponseEntity<Boolean> deleteComment(
-            @RequestBody @Valid DeleteCommentRequest deleteCommentRequest) {
+    public ResponseEntity<Response> deleteComment(@RequestBody @Valid DeleteCommentRequest deleteCommentRequest) {
 
-        return ResponseEntity.ok(commentService.deleteComment(deleteCommentRequest));
+        commentService.deleteComment(deleteCommentRequest);
+
+        return ResponseEntity.ok().body(Response.ok());
     }
 }

--- a/src/main/java/com/example/unknowngserver/comment/dto/CommentDto.java
+++ b/src/main/java/com/example/unknowngserver/comment/dto/CommentDto.java
@@ -10,15 +10,21 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class CommentDto {
     private Long id;
     private String content;
     private String author;
     private LocalDateTime registeredAt;
 
-    public static CommentDto fromEntity(Comment comment) {
+    @Builder
+    public CommentDto(Long id, String content, String author, LocalDateTime registeredAt) {
+        this.id = id;
+        this.content = content;
+        this.author = author;
+        this.registeredAt = registeredAt;
+    }
+
+    public static CommentDto fromComment(Comment comment) {
         return CommentDto.builder()
                 .id(comment.getId())
                 .content(comment.getContent())

--- a/src/main/java/com/example/unknowngserver/comment/dto/CommentInfo.java
+++ b/src/main/java/com/example/unknowngserver/comment/dto/CommentInfo.java
@@ -9,13 +9,19 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class CommentInfo {
     private Long id;
     private String author;
     private String content;
     private LocalDateTime createDate;
+
+    @Builder
+    public CommentInfo(Long id, String author, String content, LocalDateTime createDate) {
+        this.id = id;
+        this.author = author;
+        this.content = content;
+        this.createDate = createDate;
+    }
 
     public static CommentInfo fromCommentDto(CommentDto commentDto) {
         return CommentInfo.builder()

--- a/src/main/java/com/example/unknowngserver/comment/entity/Comment.java
+++ b/src/main/java/com/example/unknowngserver/comment/entity/Comment.java
@@ -9,8 +9,6 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Getter
 @Entity
 @SQLDelete(sql = "UPDATE comment SET deleted = true, deleted_at = current_timestamp WHERE id = ? ")
@@ -24,10 +22,21 @@ public class Comment {
     private String password;
     private LocalDateTime registeredAt;
 
-    @Builder.Default
-    private boolean deleted = false;
+    private boolean deleted;
     private LocalDateTime deletedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Article article;
+
+    @Builder
+    public Comment(Long id, String content, String author, String password, LocalDateTime registeredAt, boolean deleted, LocalDateTime deletedAt, Article article) {
+        this.id = id;
+        this.content = content;
+        this.author = author;
+        this.password = password;
+        this.registeredAt = registeredAt;
+        this.deleted = deleted;
+        this.deletedAt = deletedAt;
+        this.article = article;
+    }
 }

--- a/src/main/java/com/example/unknowngserver/comment/service/CommentService.java
+++ b/src/main/java/com/example/unknowngserver/comment/service/CommentService.java
@@ -7,52 +7,54 @@ import com.example.unknowngserver.comment.dto.DeleteCommentRequest;
 import com.example.unknowngserver.comment.dto.SubmitCommentRequest;
 import com.example.unknowngserver.comment.entity.Comment;
 import com.example.unknowngserver.comment.repository.CommentRepository;
+import com.example.unknowngserver.common.dto.PageNumber;
 import com.example.unknowngserver.exception.ArticleException;
 import com.example.unknowngserver.exception.CommentException;
 import com.example.unknowngserver.exception.ErrorCode;
-import com.example.unknowngserver.report.entity.ReportComment;
 import com.example.unknowngserver.report.repository.ReportCommentRepository;
+import com.example.unknowngserver.util.PasswordUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 
+    private static final int PAGE_SIZE = 10;
+
     private final CommentRepository commentRepository;
     private final ArticleRepository articleRepository;
     private final ReportCommentRepository reportCommentRepository;
+    private final PasswordUtil passwordUtil;
 
     @Transactional(readOnly = true)
-    public List<CommentDto> getComments(Long articleId, Integer page) {
+    public List<CommentDto> getComments(Long articleId, PageNumber page) {
 
         Article article = findArticle(articleId);
 
-        PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by("id").descending());
+        PageRequest pageRequest = PageRequest.of(page.getPage(), PAGE_SIZE, Sort.by("id").descending());
 
         Page<Comment> commentPageList = commentRepository.findAllByArticle(article, pageRequest);
 
         return commentPageList.stream()
-                .map(CommentDto::fromEntity)
+                .map(CommentDto::fromComment)
                 .collect(Collectors.toList());
     }
 
     @Transactional
-    public boolean createComment(SubmitCommentRequest submitCommentRequest) {
+    public void createComment(SubmitCommentRequest submitCommentRequest) {
 
         Article article = findArticle(submitCommentRequest.getArticleId());
 
-        String encPassword = BCrypt.hashpw(submitCommentRequest.getPassword(), BCrypt.gensalt());
+        String encPassword = passwordUtil.encodePassword(submitCommentRequest.getPassword());
 
         Comment comment = Comment.builder()
                 .content(submitCommentRequest.getContent())
@@ -63,25 +65,19 @@ public class CommentService {
                 .build();
 
         commentRepository.save(comment);
-
-        return true;
     }
 
     @Transactional
-    public boolean deleteComment(DeleteCommentRequest deleteCommentRequest) {
+    public void deleteComment(DeleteCommentRequest deleteCommentRequest) {
 
         Comment comment = commentRepository.findById(deleteCommentRequest.getCommentId())
                 .orElseThrow(() -> new CommentException(ErrorCode.COMMENT_NOT_FOUND));
 
-        if (!BCrypt.checkpw(deleteCommentRequest.getPassword(), comment.getPassword())) {
-            throw new CommentException(ErrorCode.NO_PERMISSION);
-        }
+        passwordUtil.isPasswordValid(deleteCommentRequest.getPassword(), comment.getPassword());
 
-        Optional<ReportComment> reportComment = reportCommentRepository.findByComment(comment);
-        reportComment.ifPresent(reportCommentRepository::delete);
+        reportCommentRepository.findByComment(comment).ifPresent(reportCommentRepository::delete);
 
         commentRepository.delete(comment);
-        return true;
     }
 
     private Article findArticle(Long articleId) {

--- a/src/main/java/com/example/unknowngserver/common/dto/Keyword.java
+++ b/src/main/java/com/example/unknowngserver/common/dto/Keyword.java
@@ -1,0 +1,13 @@
+package com.example.unknowngserver.common.dto;
+
+import lombok.Getter;
+
+@Getter
+public class Keyword {
+
+    private String keyword;
+
+    public Keyword(String keyword) {
+        this.keyword = keyword;
+    }
+}

--- a/src/main/java/com/example/unknowngserver/common/dto/PageNumber.java
+++ b/src/main/java/com/example/unknowngserver/common/dto/PageNumber.java
@@ -1,0 +1,17 @@
+package com.example.unknowngserver.common.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PageNumber {
+
+    private Integer page;
+
+    public PageNumber(Integer page) {
+        this.page = validateRequestPage(page);
+    }
+
+    private int validateRequestPage(Integer page){
+        return page == null ? 0 : Math.max(page - 1, 0);
+    }
+}

--- a/src/main/java/com/example/unknowngserver/common/dto/Response.java
+++ b/src/main/java/com/example/unknowngserver/common/dto/Response.java
@@ -1,19 +1,20 @@
 package com.example.unknowngserver.common.dto;
 
+import com.example.unknowngserver.common.type.ResponseType;
 import lombok.Getter;
 
 @Getter
 public class Response {
 
-    private String code;
-    private String message;
+    private final String code;
+    private final String message;
 
-    public Response (String code, String message) {
-        this.code = code;
-        this.message = message;
+    public Response(ResponseType responseType) {
+        this.code = responseType.getHttpStatus().toString();
+        this.message = responseType.getResponseMessage();
     }
 
     public static Response ok() {
-        return new Response("200", "성공");
+        return new Response(ResponseType.OK);
     }
 }

--- a/src/main/java/com/example/unknowngserver/common/dto/Response.java
+++ b/src/main/java/com/example/unknowngserver/common/dto/Response.java
@@ -1,0 +1,19 @@
+package com.example.unknowngserver.common.dto;
+
+import lombok.Getter;
+
+@Getter
+public class Response {
+
+    private String code;
+    private String message;
+
+    public Response (String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public static Response ok() {
+        return new Response("200", "성공");
+    }
+}

--- a/src/main/java/com/example/unknowngserver/common/type/ResponseType.java
+++ b/src/main/java/com/example/unknowngserver/common/type/ResponseType.java
@@ -1,0 +1,15 @@
+package com.example.unknowngserver.common.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseType {
+
+    OK(HttpStatus.OK, "성공");
+
+    private final HttpStatus httpStatus;
+    private final String responseMessage;
+}

--- a/src/main/java/com/example/unknowngserver/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/unknowngserver/config/JpaAuditingConfig.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class JpaAuditingConfiguration {
+public class JpaAuditingConfig {
 }

--- a/src/main/java/com/example/unknowngserver/config/SecurityConfig.java
+++ b/src/main/java/com/example/unknowngserver/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.example.unknowngserver.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder encoderPassword() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http.csrf().disable();
+        http.authorizeRequests()
+                .anyRequest().permitAll();
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/unknowngserver/exception/ErrorCode.java
+++ b/src/main/java/com/example/unknowngserver/exception/ErrorCode.java
@@ -8,12 +8,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    ARTICLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 게시글을 찾을 수 없습니다"),
-    COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다"),
-    REPORT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 신고 내역을 찾을 수 없습니다"),
+    ARTICLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 댓글을 찾을 수 없습니다."),
+    REPORT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 신고 내역을 찾을 수 없습니다."),
 
-    REPORT_DETAIL_CONTENT_TYPE_NOT_SUPPORTED(HttpStatus.EXPECTATION_FAILED, "해당 리포트 컨텐츠 타입이 지원되지 않습니다"),
-    NO_PERMISSION(HttpStatus.FORBIDDEN,"요청에 대한 권한이 없습니다.");
+    REPORT_DETAIL_CONTENT_TYPE_NOT_SUPPORTED(HttpStatus.EXPECTATION_FAILED, "해당 리포트 컨텐츠 타입이 지원되지 않습니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN,"요청에 대한 권한이 없습니다."),
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/example/unknowngserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/unknowngserver/exception/GlobalExceptionHandler.java
@@ -21,4 +21,9 @@ public class GlobalExceptionHandler {
     public ErrorResponse reportExceptionHandler(ReportException e) {
         return new ErrorResponse(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
     }
+
+    @ExceptionHandler(PasswordException.class)
+    public ErrorResponse passwordExceptionHandler(PasswordException e) {
+        return new ErrorResponse(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
 }

--- a/src/main/java/com/example/unknowngserver/exception/PasswordException.java
+++ b/src/main/java/com/example/unknowngserver/exception/PasswordException.java
@@ -1,0 +1,17 @@
+package com.example.unknowngserver.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PasswordException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final int status;
+    private final String errorMessage;
+
+    public PasswordException(ErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+        this.status = errorCode.getHttpStatus().value();
+        this.errorMessage = errorCode.getErrorMessage();
+    }
+}

--- a/src/main/java/com/example/unknowngserver/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/example/unknowngserver/exception/dto/ErrorResponse.java
@@ -7,11 +7,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 public class ErrorResponse {
     private int status;
     private ErrorCode errorCode;
     private String errorMessage;
+
+    @Builder
+    public ErrorResponse(int status, ErrorCode errorCode, String errorMessage) {
+        this.status = status;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
 }

--- a/src/main/java/com/example/unknowngserver/report/controller/ReportController.java
+++ b/src/main/java/com/example/unknowngserver/report/controller/ReportController.java
@@ -1,5 +1,7 @@
 package com.example.unknowngserver.report.controller;
 
+import com.example.unknowngserver.common.dto.PageNumber;
+import com.example.unknowngserver.common.dto.Response;
 import com.example.unknowngserver.report.dto.*;
 import com.example.unknowngserver.report.service.ReportService;
 import lombok.RequiredArgsConstructor;
@@ -12,49 +14,59 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/reports")
 public class ReportController {
 
     private final ReportService reportService;
 
-    @GetMapping("/reports")
-    public ResponseEntity<List<ReportBoardInfo>> getReports(@RequestParam(defaultValue = "1", required = false) Integer page) {
-
-        page = (page < 1) ? 1 : page;
+    @GetMapping()
+    public ResponseEntity<List<ReportBoardInfo>> getReports(@ModelAttribute PageNumber page) {
 
         List<ReportDto> reportDtoList = reportService.getReports(page);
 
-        return ResponseEntity.ok(reportDtoList.stream()
+        List<ReportBoardInfo> reportBoardInfoList = reportDtoList.stream()
                 .map(ReportBoardInfo::fromReportDto)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(reportBoardInfoList);
     }
 
-    @PostMapping("/reports")
-    public ResponseEntity<Boolean> submitReport(
-            @RequestBody @Valid SubmitReportRequest submitReportRequest) {
-        return ResponseEntity.ok(reportService.createReport(submitReportRequest));
+    @PostMapping()
+    public ResponseEntity<Response> submitReport(@RequestBody @Valid SubmitReportRequest submitReportRequest) {
+
+        reportService.createReport(submitReportRequest);
+
+        return ResponseEntity.ok().body(Response.ok());
     }
 
-    @GetMapping("/reports/{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<ReportDetailInfo> getReport(@PathVariable("id") Long id) {
 
         ReportDetailDto reportDetailDto = reportService.getReportDetail(id);
 
-        return ResponseEntity.ok(ReportDetailInfo.fromReportDetailDto(reportDetailDto));
+        ReportDetailInfo reportDetailInfo = ReportDetailInfo.fromReportDetailDto(reportDetailDto);
+
+        return ResponseEntity.ok(reportDetailInfo);
     }
 
-    @DeleteMapping("/reports/{id}")
-    public ResponseEntity<Boolean> deleteReport(@PathVariable("id") Long id) {
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Response> deleteReport(@PathVariable("id") Long id) {
 
-        return ResponseEntity.ok(reportService.deleteReport(id));
+        reportService.deleteReport(id);
+
+        return ResponseEntity.ok().body(Response.ok());
     }
 
-    @GetMapping("/reports/{reportId}/reportRecords")
+    @GetMapping("/{reportId}/report-records")
     public ResponseEntity<List<ReportRecordBoardInfo>> getReportRecords(@PathVariable("reportId") Long reportId,
-                                                                        @RequestParam(defaultValue = "1", required = false) Integer page) {
+                                                                        @ModelAttribute PageNumber page) {
+
         List<ReportRecordDto> reportRecordDtoList = reportService.getReportRecords(reportId, page);
 
-        return ResponseEntity.ok(reportRecordDtoList.stream()
+        List<ReportRecordBoardInfo> reportRecordBoardInfoList = reportRecordDtoList.stream()
                 .map(ReportRecordBoardInfo::fromReportRecordDto)
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(reportRecordBoardInfoList);
     }
 }

--- a/src/main/java/com/example/unknowngserver/report/controller/ReportController.java
+++ b/src/main/java/com/example/unknowngserver/report/controller/ReportController.java
@@ -19,7 +19,7 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<List<ReportBoardInfo>> getReports(@ModelAttribute PageNumber page) {
 
         List<ReportDto> reportDtoList = reportService.getReports(page);
@@ -31,7 +31,7 @@ public class ReportController {
         return ResponseEntity.ok(reportBoardInfoList);
     }
 
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<Response> submitReport(@RequestBody @Valid SubmitReportRequest submitReportRequest) {
 
         reportService.createReport(submitReportRequest);

--- a/src/main/java/com/example/unknowngserver/report/controller/ReportController.java
+++ b/src/main/java/com/example/unknowngserver/report/controller/ReportController.java
@@ -48,12 +48,9 @@ public class ReportController {
         return ResponseEntity.ok(reportService.deleteReport(id));
     }
 
-    @GetMapping("/reports/{reportId}/report-records")
+    @GetMapping("/reports/{reportId}/reportRecords")
     public ResponseEntity<List<ReportRecordBoardInfo>> getReportRecords(@PathVariable("reportId") Long reportId,
                                                                         @RequestParam(defaultValue = "1", required = false) Integer page) {
-
-        page = (page < 1) ? 1 : page;
-
         List<ReportRecordDto> reportRecordDtoList = reportService.getReportRecords(reportId, page);
 
         return ResponseEntity.ok(reportRecordDtoList.stream()

--- a/src/main/java/com/example/unknowngserver/report/dto/ReportBoardInfo.java
+++ b/src/main/java/com/example/unknowngserver/report/dto/ReportBoardInfo.java
@@ -9,13 +9,19 @@ import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class ReportBoardInfo {
     private Long reportId;
     private String reportedContentType;
     private Integer reportedCount;
     private LocalDate firstReportedAt;
+
+    @Builder
+    public ReportBoardInfo(Long reportId, String reportedContentType, Integer reportedCount, LocalDate firstReportedAt) {
+        this.reportId = reportId;
+        this.reportedContentType = reportedContentType;
+        this.reportedCount = reportedCount;
+        this.firstReportedAt = firstReportedAt;
+    }
 
     public static ReportBoardInfo fromReportDto(ReportDto reportDto){
         return ReportBoardInfo.builder()

--- a/src/main/java/com/example/unknowngserver/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/example/unknowngserver/report/dto/ReportDetailDto.java
@@ -1,7 +1,5 @@
 package com.example.unknowngserver.report.dto;
 
-import com.example.unknowngserver.report.entity.ReportArticle;
-import com.example.unknowngserver.report.entity.ReportComment;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +9,6 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class ReportDetailDto {
     private Long reportId;
     private String reportedContentType;
@@ -21,24 +17,14 @@ public class ReportDetailDto {
     private int reportedCount;
     private LocalDateTime firstReportedAt;
 
-    public static ReportDetailDto fromReportArticleEntity(ReportArticle reportArticle) {
-        return ReportDetailDto.builder()
-                .reportId(reportArticle.getId())
-                .reportedContentType(reportArticle.getContentType())
-                .targetId(reportArticle.getArticle().getId())
-                .reportedCount(reportArticle.getReportedCount())
-                .firstReportedAt(reportArticle.getFirstReportedAt())
-                .build();
-    }
-
-    public static ReportDetailDto fromReportCommentEntity(ReportComment reportComment) {
-        return ReportDetailDto.builder()
-                .reportId(reportComment.getId())
-                .reportedContentType(reportComment.getContentType())
-                .targetId(reportComment.getComment().getId())
-                .reportedCount(reportComment.getReportedCount())
-                .firstReportedAt(reportComment.getFirstReportedAt())
-                .build();
+    @Builder
+    public ReportDetailDto(Long reportId, String reportedContentType, Long targetId, String targetContent, int reportedCount, LocalDateTime firstReportedAt) {
+        this.reportId = reportId;
+        this.reportedContentType = reportedContentType;
+        this.targetId = targetId;
+        this.targetContent = targetContent;
+        this.reportedCount = reportedCount;
+        this.firstReportedAt = firstReportedAt;
     }
 }
 

--- a/src/main/java/com/example/unknowngserver/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/example/unknowngserver/report/dto/ReportDetailDto.java
@@ -20,5 +20,25 @@ public class ReportDetailDto {
     private String targetContent;
     private int reportedCount;
     private LocalDateTime firstReportedAt;
+
+    public static ReportDetailDto fromReportArticleEntity(ReportArticle reportArticle) {
+        return ReportDetailDto.builder()
+                .reportId(reportArticle.getId())
+                .reportedContentType(reportArticle.getContentType())
+                .targetId(reportArticle.getArticle().getId())
+                .reportedCount(reportArticle.getReportedCount())
+                .firstReportedAt(reportArticle.getFirstReportedAt())
+                .build();
+    }
+
+    public static ReportDetailDto fromReportCommentEntity(ReportComment reportComment) {
+        return ReportDetailDto.builder()
+                .reportId(reportComment.getId())
+                .reportedContentType(reportComment.getContentType())
+                .targetId(reportComment.getComment().getId())
+                .reportedCount(reportComment.getReportedCount())
+                .firstReportedAt(reportComment.getFirstReportedAt())
+                .build();
+    }
 }
 

--- a/src/main/java/com/example/unknowngserver/report/dto/ReportDetailInfo.java
+++ b/src/main/java/com/example/unknowngserver/report/dto/ReportDetailInfo.java
@@ -9,8 +9,6 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class ReportDetailInfo {
     private Long reportId;
     private String reportedContentType;
@@ -18,6 +16,16 @@ public class ReportDetailInfo {
     private String targetContent;
     private int reportedCount;
     private LocalDateTime firstReportedAt;
+
+    @Builder
+    public ReportDetailInfo(Long reportId, String reportedContentType, Long targetId, String targetContent, int reportedCount, LocalDateTime firstReportedAt) {
+        this.reportId = reportId;
+        this.reportedContentType = reportedContentType;
+        this.targetId = targetId;
+        this.targetContent = targetContent;
+        this.reportedCount = reportedCount;
+        this.firstReportedAt = firstReportedAt;
+    }
 
     public static ReportDetailInfo fromReportDetailDto(ReportDetailDto reportDetailDto){
         return ReportDetailInfo.builder()

--- a/src/main/java/com/example/unknowngserver/report/dto/ReportDto.java
+++ b/src/main/java/com/example/unknowngserver/report/dto/ReportDto.java
@@ -10,15 +10,21 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class ReportDto {
     private Long reportId;
     private String reportedContentType;
     private Integer reportedCount;
     private LocalDateTime firstReportedAt;
 
-    public static ReportDto fromEntity(Report report) {
+    @Builder
+    public ReportDto(Long reportId, String reportedContentType, Integer reportedCount, LocalDateTime firstReportedAt) {
+        this.reportId = reportId;
+        this.reportedContentType = reportedContentType;
+        this.reportedCount = reportedCount;
+        this.firstReportedAt = firstReportedAt;
+    }
+
+    public static ReportDto fromReport(Report report) {
         return ReportDto.builder()
                 .reportId(report.getId())
                 .reportedContentType(report.getContentType())

--- a/src/main/java/com/example/unknowngserver/report/dto/ReportRecordBoardInfo.java
+++ b/src/main/java/com/example/unknowngserver/report/dto/ReportRecordBoardInfo.java
@@ -10,12 +10,17 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class ReportRecordBoardInfo {
     private ReportType reportType;
     private String memo;
     private LocalDateTime reportedDt;
+
+    @Builder
+    public ReportRecordBoardInfo(ReportType reportType, String memo, LocalDateTime reportedDt) {
+        this.reportType = reportType;
+        this.memo = memo;
+        this.reportedDt = reportedDt;
+    }
 
     public static ReportRecordBoardInfo fromReportRecordDto(ReportRecordDto reportRecordDto) {
         return ReportRecordBoardInfo.builder()

--- a/src/main/java/com/example/unknowngserver/report/dto/ReportRecordDto.java
+++ b/src/main/java/com/example/unknowngserver/report/dto/ReportRecordDto.java
@@ -11,15 +11,21 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class ReportRecordDto {
     private Long id;
     private ReportType reportType;
     private String memo;
     private LocalDateTime reportedDt;
 
-    public static ReportRecordDto fromEntity(ReportRecord reportRecord) {
+    @Builder
+    public ReportRecordDto(Long id, ReportType reportType, String memo, LocalDateTime reportedDt) {
+        this.id = id;
+        this.reportType = reportType;
+        this.memo = memo;
+        this.reportedDt = reportedDt;
+    }
+
+    public static ReportRecordDto fromReportRecord(ReportRecord reportRecord) {
         return ReportRecordDto.builder()
                 .id(reportRecord.getId())
                 .reportType(reportRecord.getReportType())

--- a/src/main/java/com/example/unknowngserver/report/entity/Report.java
+++ b/src/main/java/com/example/unknowngserver/report/entity/Report.java
@@ -15,7 +15,7 @@ import java.util.List;
 @SuperBuilder
 @Getter
 @Entity
-@SQLDelete(sql = "UPDATE report SET processed = true, processed_at = current_timestamp WHERE id = ? ")
+@SQLDelete(sql = "UPDATE report SET processed = true, processedAt = current_timestamp WHERE id = ? ")
 @Where(clause = "processed = false")
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "content_type")

--- a/src/main/java/com/example/unknowngserver/report/entity/Report.java
+++ b/src/main/java/com/example/unknowngserver/report/entity/Report.java
@@ -11,11 +11,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor
-@AllArgsConstructor
 @SuperBuilder
 @Getter
 @Entity
-@SQLDelete(sql = "UPDATE report SET processed = true, processedAt = current_timestamp WHERE id = ? ")
+@SQLDelete(sql = "UPDATE report SET processed = true, processed_at = current_timestamp WHERE id = ? ")
 @Where(clause = "processed = false")
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn(name = "content_type")

--- a/src/main/java/com/example/unknowngserver/report/entity/ReportArticle.java
+++ b/src/main/java/com/example/unknowngserver/report/entity/ReportArticle.java
@@ -13,12 +13,11 @@ import javax.persistence.FetchType;
 import javax.persistence.OneToOne;
 
 @NoArgsConstructor
-@AllArgsConstructor
 @SuperBuilder
 @Getter
 @Entity
 @DiscriminatorValue("ARTICLE")
-@SQLDelete(sql = "UPDATE report SET processed = true, processedAt = current_timestamp WHERE id = ? ")
+@SQLDelete(sql = "UPDATE report SET processed = true, processed_at = current_timestamp WHERE id = ? ")
 public class ReportArticle extends Report {
     @OneToOne(fetch = FetchType.LAZY)
     private Article article;

--- a/src/main/java/com/example/unknowngserver/report/entity/ReportArticle.java
+++ b/src/main/java/com/example/unknowngserver/report/entity/ReportArticle.java
@@ -18,7 +18,7 @@ import javax.persistence.OneToOne;
 @Getter
 @Entity
 @DiscriminatorValue("ARTICLE")
-@SQLDelete(sql = "UPDATE report SET processed = true, processed_at = current_timestamp WHERE id = ? ")
+@SQLDelete(sql = "UPDATE report SET processed = true, processedAt = current_timestamp WHERE id = ? ")
 public class ReportArticle extends Report {
     @OneToOne(fetch = FetchType.LAZY)
     private Article article;

--- a/src/main/java/com/example/unknowngserver/report/entity/ReportComment.java
+++ b/src/main/java/com/example/unknowngserver/report/entity/ReportComment.java
@@ -13,12 +13,11 @@ import javax.persistence.FetchType;
 import javax.persistence.OneToOne;
 
 @NoArgsConstructor
-@AllArgsConstructor
 @SuperBuilder
 @Getter
 @Entity
 @DiscriminatorValue("COMMENT")
-@SQLDelete(sql = "UPDATE report SET processed = true, processedAt = current_timestamp WHERE id = ? ")
+@SQLDelete(sql = "UPDATE report SET processed = true, processed_at = current_timestamp WHERE id = ? ")
 public class ReportComment extends Report {
     @OneToOne(fetch = FetchType.LAZY)
     private Comment comment;

--- a/src/main/java/com/example/unknowngserver/report/entity/ReportComment.java
+++ b/src/main/java/com/example/unknowngserver/report/entity/ReportComment.java
@@ -18,7 +18,7 @@ import javax.persistence.OneToOne;
 @Getter
 @Entity
 @DiscriminatorValue("COMMENT")
-@SQLDelete(sql = "UPDATE report SET processed = true, processed_at = current_timestamp WHERE id = ? ")
+@SQLDelete(sql = "UPDATE report SET processed = true, processedAt = current_timestamp WHERE id = ? ")
 public class ReportComment extends Report {
     @OneToOne(fetch = FetchType.LAZY)
     private Comment comment;

--- a/src/main/java/com/example/unknowngserver/report/entity/ReportRecord.java
+++ b/src/main/java/com/example/unknowngserver/report/entity/ReportRecord.java
@@ -13,6 +13,8 @@ import java.time.LocalDateTime;
 @Builder
 @Getter
 @Entity
+@SQLDelete(sql = "UPDATE report_record SET isHandled = true WHERE id = ? ")
+@Where(clause = "isHandled = false")
 public class ReportRecord {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,4 +25,11 @@ public class ReportRecord {
     private ReportType reportType;
     private String memo;
     private LocalDateTime reportedDt;
+
+    @Builder.Default
+    private boolean isHandled = Boolean.FALSE;
+
+    public void addReport(Report report) {
+        this.report = report;
+    }
 }

--- a/src/main/java/com/example/unknowngserver/report/entity/ReportRecord.java
+++ b/src/main/java/com/example/unknowngserver/report/entity/ReportRecord.java
@@ -2,19 +2,13 @@ package com.example.unknowngserver.report.entity;
 
 import com.example.unknowngserver.report.type.ReportType;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 @Getter
 @Entity
-@SQLDelete(sql = "UPDATE report_record SET isHandled = true WHERE id = ? ")
-@Where(clause = "isHandled = false")
 public class ReportRecord {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,10 +20,12 @@ public class ReportRecord {
     private String memo;
     private LocalDateTime reportedDt;
 
-    @Builder.Default
-    private boolean isHandled = Boolean.FALSE;
-
-    public void addReport(Report report) {
+    @Builder
+    public ReportRecord(Long id, Report report, ReportType reportType, String memo, LocalDateTime reportedDt) {
+        this.id = id;
         this.report = report;
+        this.reportType = reportType;
+        this.memo = memo;
+        this.reportedDt = reportedDt;
     }
 }

--- a/src/main/java/com/example/unknowngserver/report/service/ReportArticleService.java
+++ b/src/main/java/com/example/unknowngserver/report/service/ReportArticleService.java
@@ -20,28 +20,15 @@ import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
-public class ReportArticleService {
+public class ReportArticleService implements ReportContentService {
 
     private final ReportArticleRepository reportArticleRepository;
     private final ReportRecordRepository reportRecordRepository;
     private final ArticleRepository articleRepository;
 
-    public ReportDetailDto getReportArticleDetail(Report report) {
-
-        ReportArticle reportArticle = (ReportArticle) report;
-
-        return ReportDetailDto.builder()
-                .reportId(reportArticle.getId())
-                .reportedContentType(reportArticle.getContentType())
-                .targetId(reportArticle.getArticle().getId())
-                .targetContent(reportArticle.getArticle().getContent())
-                .reportedCount(reportArticle.getReportedCount())
-                .firstReportedAt(reportArticle.getFirstReportedAt())
-                .build();
-    }
-
+    @Override
     @Transactional
-    public void createReportArticle(SubmitReportRequest submitReportRequest) {
+    public void createReport(SubmitReportRequest submitReportRequest) {
 
         Article article = findArticle(submitReportRequest.getContentId());
         LocalDateTime currentTimeStamp = LocalDateTime.now();
@@ -63,10 +50,29 @@ public class ReportArticleService {
 
     }
 
-    public void deleteReportArticle(ReportArticle report) {
+    @Override
+    @Transactional
+    public void deleteReport(Report report) {
 
-        articleRepository.delete(report.getArticle());
-        reportArticleRepository.delete(report);
+        ReportArticle reportArticle = (ReportArticle) report;
+
+        articleRepository.delete(reportArticle.getArticle());
+        reportArticleRepository.delete(reportArticle);
+    }
+
+    @Override
+    public ReportDetailDto getReportDetail(Report report) {
+
+        ReportArticle reportArticle = (ReportArticle) report;
+
+        return ReportDetailDto.builder()
+                .reportId(reportArticle.getId())
+                .reportedContentType(reportArticle.getContentType())
+                .targetId(reportArticle.getArticle().getId())
+                .targetContent(reportArticle.getArticle().getContent())
+                .reportedCount(reportArticle.getReportedCount())
+                .firstReportedAt(reportArticle.getFirstReportedAt())
+                .build();
 
     }
 

--- a/src/main/java/com/example/unknowngserver/report/service/ReportArticleService.java
+++ b/src/main/java/com/example/unknowngserver/report/service/ReportArticleService.java
@@ -6,7 +6,6 @@ import com.example.unknowngserver.exception.ArticleException;
 import com.example.unknowngserver.exception.ErrorCode;
 import com.example.unknowngserver.report.dto.ReportDetailDto;
 import com.example.unknowngserver.report.dto.SubmitReportRequest;
-import com.example.unknowngserver.report.entity.Report;
 import com.example.unknowngserver.report.entity.ReportArticle;
 import com.example.unknowngserver.report.entity.ReportRecord;
 import com.example.unknowngserver.report.repository.ReportArticleRepository;
@@ -26,18 +25,11 @@ public class ReportArticleService {
     private final ReportRecordRepository reportRecordRepository;
     private final ArticleRepository articleRepository;
 
-    public ReportDetailDto getReportArticleDetail(Report report) {
 
-        ReportArticle reportArticle = (ReportArticle) report;
+    @Transactional(readOnly = true)
+    public ReportDetailDto getReportArticleDetail(ReportArticle report) {
 
-        return ReportDetailDto.builder()
-                .reportId(reportArticle.getId())
-                .reportedContentType(reportArticle.getContentType())
-                .targetId(reportArticle.getArticle().getId())
-                .targetContent(reportArticle.getArticle().getContent())
-                .reportedCount(reportArticle.getReportedCount())
-                .firstReportedAt(reportArticle.getFirstReportedAt())
-                .build();
+        return ReportDetailDto.fromReportArticleEntity(report);
     }
 
     @Transactional
@@ -47,7 +39,7 @@ public class ReportArticleService {
         LocalDateTime currentTimeStamp = LocalDateTime.now();
 
         ReportArticle reportArticle = reportArticleRepository.findByArticle(article)
-                .orElseGet(() -> reportArticleRepository.save(ReportArticle.builder()
+                .orElse(reportArticleRepository.save(ReportArticle.builder()
                         .firstReportedAt(currentTimeStamp)
                         .article(article)
                         .build()));

--- a/src/main/java/com/example/unknowngserver/report/service/ReportCommentService.java
+++ b/src/main/java/com/example/unknowngserver/report/service/ReportCommentService.java
@@ -6,7 +6,6 @@ import com.example.unknowngserver.exception.CommentException;
 import com.example.unknowngserver.exception.ErrorCode;
 import com.example.unknowngserver.report.dto.ReportDetailDto;
 import com.example.unknowngserver.report.dto.SubmitReportRequest;
-import com.example.unknowngserver.report.entity.Report;
 import com.example.unknowngserver.report.entity.ReportComment;
 import com.example.unknowngserver.report.entity.ReportRecord;
 import com.example.unknowngserver.report.repository.ReportCommentRepository;
@@ -26,28 +25,19 @@ public class ReportCommentService {
     private final ReportRecordRepository reportRecordRepository;
     private final CommentRepository commentRepository;
 
-    public ReportDetailDto getReportCommentDetail(Report report) {
+    @Transactional(readOnly = true)
+    public ReportDetailDto getReportCommentDetail(ReportComment report) {
 
-        ReportComment reportComment = (ReportComment) report;
-
-        return ReportDetailDto.builder()
-                .reportId(reportComment.getId())
-                .reportedContentType(reportComment.getContentType())
-                .targetId(reportComment.getComment().getId())
-                .targetContent(reportComment.getComment().getContent())
-                .reportedCount(reportComment.getReportedCount())
-                .firstReportedAt(reportComment.getFirstReportedAt())
-                .build();
+        return ReportDetailDto.fromReportCommentEntity(report);
     }
 
     @Transactional
     public boolean createReportComment(SubmitReportRequest submitReportRequest) {
-
         Comment comment = findComment(submitReportRequest.getContentId());
         LocalDateTime currentTimeStamp = LocalDateTime.now();
 
         ReportComment reportComment = reportCommentRepository.findByComment(comment)
-                .orElseGet(() -> reportCommentRepository.save(ReportComment.builder()
+                .orElse(reportCommentRepository.save(ReportComment.builder()
                         .firstReportedAt(currentTimeStamp)
                         .comment(comment)
                         .build()));

--- a/src/main/java/com/example/unknowngserver/report/service/ReportCommentService.java
+++ b/src/main/java/com/example/unknowngserver/report/service/ReportCommentService.java
@@ -20,28 +20,15 @@ import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
-public class ReportCommentService {
+public class ReportCommentService implements ReportContentService {
 
     private final ReportCommentRepository reportCommentRepository;
     private final ReportRecordRepository reportRecordRepository;
     private final CommentRepository commentRepository;
 
-    public ReportDetailDto getReportCommentDetail(Report report) {
-
-        ReportComment reportComment = (ReportComment) report;
-
-        return ReportDetailDto.builder()
-                .reportId(reportComment.getId())
-                .reportedContentType(reportComment.getContentType())
-                .targetId(reportComment.getComment().getId())
-                .targetContent(reportComment.getComment().getContent())
-                .reportedCount(reportComment.getReportedCount())
-                .firstReportedAt(reportComment.getFirstReportedAt())
-                .build();
-    }
-
+    @Override
     @Transactional
-    public void createReportComment(SubmitReportRequest submitReportRequest) {
+    public void createReport(SubmitReportRequest submitReportRequest) {
 
         Comment comment = findComment(submitReportRequest.getContentId());
         LocalDateTime currentTimeStamp = LocalDateTime.now();
@@ -63,10 +50,30 @@ public class ReportCommentService {
 
     }
 
-    public void deleteReportComment(ReportComment report) {
+    @Override
+    @Transactional
+    public void deleteReport(Report report) {
 
-        commentRepository.delete(report.getComment());
-        reportCommentRepository.delete(report);
+        ReportComment reportComment = (ReportComment) report;
+
+        commentRepository.delete(reportComment.getComment());
+        reportCommentRepository.delete(reportComment);
+
+    }
+
+    @Override
+    public ReportDetailDto getReportDetail(Report report) {
+
+        ReportComment reportComment = (ReportComment) report;
+
+        return ReportDetailDto.builder()
+                .reportId(reportComment.getId())
+                .reportedContentType(reportComment.getContentType())
+                .targetId(reportComment.getComment().getId())
+                .targetContent(reportComment.getComment().getContent())
+                .reportedCount(reportComment.getReportedCount())
+                .firstReportedAt(reportComment.getFirstReportedAt())
+                .build();
 
     }
 

--- a/src/main/java/com/example/unknowngserver/report/service/ReportContentService.java
+++ b/src/main/java/com/example/unknowngserver/report/service/ReportContentService.java
@@ -1,0 +1,13 @@
+package com.example.unknowngserver.report.service;
+
+import com.example.unknowngserver.report.dto.ReportDetailDto;
+import com.example.unknowngserver.report.dto.SubmitReportRequest;
+import com.example.unknowngserver.report.entity.Report;
+
+public interface ReportContentService {
+
+    void createReport(SubmitReportRequest submitReportRequest);
+    void deleteReport(Report report);
+    ReportDetailDto getReportDetail(Report report);
+
+}

--- a/src/main/java/com/example/unknowngserver/report/service/ReportService.java
+++ b/src/main/java/com/example/unknowngserver/report/service/ReportService.java
@@ -8,11 +8,10 @@ import com.example.unknowngserver.report.dto.ReportDto;
 import com.example.unknowngserver.report.dto.ReportRecordDto;
 import com.example.unknowngserver.report.dto.SubmitReportRequest;
 import com.example.unknowngserver.report.entity.Report;
-import com.example.unknowngserver.report.entity.ReportArticle;
-import com.example.unknowngserver.report.entity.ReportComment;
 import com.example.unknowngserver.report.entity.ReportRecord;
 import com.example.unknowngserver.report.repository.ReportRecordRepository;
 import com.example.unknowngserver.report.repository.ReportRepository;
+import com.example.unknowngserver.report.type.ContentType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -31,8 +30,6 @@ public class ReportService {
 
     private final ReportRepository reportRepository;
     private final ReportRecordRepository reportRecordRepository;
-    private final ReportArticleService reportArticleService;
-    private final ReportCommentService reportCommentService;
 
     @Transactional(readOnly = true)
     public List<ReportDto> getReports(PageNumber page) {
@@ -65,30 +62,18 @@ public class ReportService {
 
         Report report = findReport(reportId);
 
-        if ("ARTICLE".equals(report.getContentType())) {
-            return reportArticleService.getReportArticleDetail(report);
-        }
+        ReportContentService reportContentService = ContentType.getReportContentService(report.getContentType());
 
-        if ("COMMENT".equals(report.getContentType())) {
-            return reportCommentService.getReportCommentDetail(report);
-        }
+        return reportContentService.getReportDetail(report);
 
-        throw new ReportException(ErrorCode.REPORT_DETAIL_CONTENT_TYPE_NOT_SUPPORTED);
     }
 
     public void createReport(SubmitReportRequest submitReportRequest) {
 
-        if ("ARTICLE".equals(submitReportRequest.getContentType())) {
-            reportArticleService.createReportArticle(submitReportRequest);
-            return;
-        }
+        ReportContentService reportContentService = ContentType.getReportContentService(submitReportRequest.getContentType());
 
-        if ("COMMENT".equals(submitReportRequest.getContentType())) {
-            reportCommentService.createReportComment(submitReportRequest);
-            return;
-        }
+        reportContentService.createReport(submitReportRequest);
 
-        throw new ReportException(ErrorCode.REPORT_DETAIL_CONTENT_TYPE_NOT_SUPPORTED);
     }
 
     @Transactional
@@ -96,17 +81,10 @@ public class ReportService {
 
         Report report = findReport(reportId);
 
-        if ("ARTICLE".equals(report.getContentType())) {
-            reportArticleService.deleteReportArticle((ReportArticle) report);
-            return;
-        }
+        ReportContentService reportContentService = ContentType.getReportContentService(report.getContentType());
 
-        if ("COMMENT".equals(report.getContentType())) {
-            reportCommentService.deleteReportComment((ReportComment) report);
-            return;
-        }
+        reportContentService.deleteReport(report);
 
-        throw new ReportException(ErrorCode.REPORT_DETAIL_CONTENT_TYPE_NOT_SUPPORTED);
     }
 
     private Report findReport(Long reportId) {

--- a/src/main/java/com/example/unknowngserver/report/service/ReportService.java
+++ b/src/main/java/com/example/unknowngserver/report/service/ReportService.java
@@ -33,7 +33,7 @@ public class ReportService {
     @Transactional(readOnly = true)
     public List<ReportDto> getReports(Integer page) {
 
-        PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by("reportedCount").descending());
+        PageRequest pageRequest = PageRequest.of(page - 1, 10, Sort.by("id").descending());
 
         Page<Report> reportPageList = reportRepository.findAll(pageRequest);
 
@@ -54,22 +54,6 @@ public class ReportService {
         return reportRecordPageList.stream()
                 .map(ReportRecordDto::fromEntity)
                 .collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
-    public ReportDetailDto getReportDetail(Long reportId) {
-
-        Report report = findReport(reportId);
-
-        if (report.getContentType().equals("ARTICLE")) {
-            return reportArticleService.getReportArticleDetail(report);
-        }
-
-        if (report.getContentType().equals("COMMENT")) {
-            return reportCommentService.getReportCommentDetail(report);
-        }
-
-        throw new ReportException(ErrorCode.REPORT_DETAIL_CONTENT_TYPE_NOT_SUPPORTED);
     }
 
     public boolean createReport(SubmitReportRequest submitReportRequest) {
@@ -100,7 +84,22 @@ public class ReportService {
         throw new ReportException(ErrorCode.REPORT_DETAIL_CONTENT_TYPE_NOT_SUPPORTED);
     }
 
-    private Report findReport(Long reportId) {
+    public ReportDetailDto getReportDetail(Long reportId) {
+
+        Report report = findReport(reportId);
+
+        if (report.getContentType().equals("ARTICLE")) {
+            return reportArticleService.getReportArticleDetail((ReportArticle) report);
+        }
+
+        if (report.getContentType().equals("COMMENT")) {
+            return reportCommentService.getReportCommentDetail((ReportComment) report);
+        }
+
+        throw new ReportException(ErrorCode.REPORT_DETAIL_CONTENT_TYPE_NOT_SUPPORTED);
+    }
+
+    public Report findReport(Long reportId) {
         return reportRepository.findById(reportId)
                 .orElseThrow(() -> new ReportException(ErrorCode.REPORT_NOT_FOUND));
     }

--- a/src/main/java/com/example/unknowngserver/report/type/ContentType.java
+++ b/src/main/java/com/example/unknowngserver/report/type/ContentType.java
@@ -1,5 +1,28 @@
 package com.example.unknowngserver.report.type;
 
+import com.example.unknowngserver.exception.ErrorCode;
+import com.example.unknowngserver.exception.ReportException;
+import com.example.unknowngserver.report.service.ReportContentService;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
 public enum ContentType {
-    ARTICLE, COMMENT
+    ARTICLE, COMMENT;
+
+    private ReportContentService reportContentService;
+
+    public void addReportContentService(ReportContentService reportContentService) {
+        this.reportContentService = reportContentService;
+    }
+
+    public static ReportContentService getReportContentService(String input) {
+        return Arrays.stream(values())
+                .filter(e -> e.toString().equals(input))
+                .findFirst()
+                .orElseThrow(() -> new ReportException(ErrorCode.REPORT_DETAIL_CONTENT_TYPE_NOT_SUPPORTED))
+                .getReportContentService();
+    }
+
 }

--- a/src/main/java/com/example/unknowngserver/report/type/ContentTypeDependencyInjector.java
+++ b/src/main/java/com/example/unknowngserver/report/type/ContentTypeDependencyInjector.java
@@ -22,7 +22,7 @@ public class ContentTypeDependencyInjector {
                 type.addReportContentService(reportArticleService);
             }
 
-            if (type.equals(ContentType.ARTICLE)) {
+            if (type.equals(ContentType.COMMENT)) {
                 type.addReportContentService(reportCommentService);
             }
         }

--- a/src/main/java/com/example/unknowngserver/report/type/ContentTypeDependencyInjector.java
+++ b/src/main/java/com/example/unknowngserver/report/type/ContentTypeDependencyInjector.java
@@ -1,0 +1,30 @@
+package com.example.unknowngserver.report.type;
+
+import com.example.unknowngserver.report.service.ReportArticleService;
+import com.example.unknowngserver.report.service.ReportCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+
+@Configuration
+@RequiredArgsConstructor
+public class ContentTypeDependencyInjector {
+
+    private final ReportArticleService reportArticleService;
+    private final ReportCommentService reportCommentService;
+
+    @PostConstruct
+    public void inject() {
+        for (ContentType type : ContentType.values()) {
+
+            if (type.equals(ContentType.ARTICLE)) {
+                type.addReportContentService(reportArticleService);
+            }
+
+            if (type.equals(ContentType.ARTICLE)) {
+                type.addReportContentService(reportCommentService);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/unknowngserver/report/type/ReportType.java
+++ b/src/main/java/com/example/unknowngserver/report/type/ReportType.java
@@ -6,4 +6,3 @@ public enum ReportType {
     ILLEGAL_ADVERTISING,
     OTHER
 }
-

--- a/src/main/java/com/example/unknowngserver/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/unknowngserver/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,42 @@
+package com.example.unknowngserver.security;
+
+import com.example.unknowngserver.exception.dto.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.example.unknowngserver.exception.ErrorCode.NO_PERMISSION;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        setResponse(response);
+
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.builder()
+                .status(NO_PERMISSION.getHttpStatus().value())
+                .errorCode(NO_PERMISSION)
+                .errorMessage(NO_PERMISSION.getErrorMessage())
+                .build()));
+        response.getWriter().flush();
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(NO_PERMISSION.getHttpStatus().value());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+    }
+
+}

--- a/src/main/java/com/example/unknowngserver/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/unknowngserver/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.example.unknowngserver.security;
+
+import com.example.unknowngserver.exception.dto.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static com.example.unknowngserver.exception.ErrorCode.UNAUTHORIZED_USER;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+
+        setResponse(response);
+
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.builder()
+                .status(UNAUTHORIZED_USER.getHttpStatus().value())
+                .errorCode(UNAUTHORIZED_USER)
+                .errorMessage(UNAUTHORIZED_USER.getErrorMessage())
+                .build()));
+        response.getWriter().flush();
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(UNAUTHORIZED_USER.getHttpStatus().value());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+    }
+
+}

--- a/src/main/java/com/example/unknowngserver/util/PasswordUtil.java
+++ b/src/main/java/com/example/unknowngserver/util/PasswordUtil.java
@@ -1,0 +1,25 @@
+package com.example.unknowngserver.util;
+
+import com.example.unknowngserver.exception.ErrorCode;
+import com.example.unknowngserver.exception.PasswordException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordUtil {
+
+    private final PasswordEncoder passwordEncoder;
+
+    public void isPasswordValid(String password, String encodedPassword) {
+
+        if (!passwordEncoder.matches(password, encodedPassword)) {
+            throw new PasswordException(ErrorCode.NO_PERMISSION);
+        }
+    }
+
+    public String encodePassword(String password){
+        return passwordEncoder.encode(password);
+    }
+}

--- a/src/test/java/com/example/unknowngserver/report/service/ReportArticleServiceTest.java
+++ b/src/test/java/com/example/unknowngserver/report/service/ReportArticleServiceTest.java
@@ -1,29 +1,187 @@
 package com.example.unknowngserver.report.service;
 
+import com.example.unknowngserver.article.entity.Article;
+import com.example.unknowngserver.article.repository.ArticleRepository;
+import com.example.unknowngserver.report.dto.ReportDetailDto;
+import com.example.unknowngserver.report.dto.SubmitReportRequest;
+import com.example.unknowngserver.report.entity.ReportArticle;
+import com.example.unknowngserver.report.entity.ReportRecord;
+import com.example.unknowngserver.report.repository.ReportArticleRepository;
+import com.example.unknowngserver.report.repository.ReportRecordRepository;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class ReportArticleServiceTest {
 
+    @Mock
+    private ReportArticleRepository reportArticleRepository;
+    @Mock
+    private ReportRecordRepository reportRecordRepository;
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @InjectMocks
+    private ReportArticleService reportArticleService;
+
     @Test
+    @DisplayName("신고 상세 내용 조회 API 서비스 테스트 성공 - 게시글 신고")
     void getReportArticleDetail() {
+
         //given
+        Article article = Article.builder()
+                .id(1L)
+                .title("test")
+                .content("테스트용")
+                .author("test")
+                .password("1234")
+                .registeredAt(LocalDateTime.now())
+                .build();
+
+        ReportArticle reportArticle = ReportArticle.builder()
+                .id(1L)
+                .firstReportedAt(LocalDateTime.now())
+                .contentType("ARTICLE")
+                .reportedCount(1)
+                .article(article)
+                .build();
+
         //when
+        ReportDetailDto reportDetailDto = reportArticleService.getReportArticleDetail(reportArticle);
+
         //then
+        assertEquals(1L, reportDetailDto.getReportId());
+        assertEquals("ARTICLE", reportDetailDto.getReportedContentType());
+        assertEquals(1, reportDetailDto.getReportedCount());
+        assertEquals(1L, reportDetailDto.getTargetId());
+        assertEquals("테스트용", reportDetailDto.getTargetContent());
+
     }
 
     @Test
+    @DisplayName("신고 등록 API 서비스 테스트 성공 - 게시글 신고 (기존 게시글에 신고내역이 없을때)")
     void createReportArticle() {
+
         //given
-        //when
-        //then
+        Article article = Article.builder()
+                .id(1L)
+                .title("test")
+                .content("테스트용")
+                .author("test")
+                .password("1234")
+                .registeredAt(LocalDateTime.now())
+                .build();
+
+        ReportArticle reportArticle = ReportArticle.builder()
+                .id(1L)
+                .firstReportedAt(LocalDateTime.now())
+                .contentType("ARTICLE")
+                .reportedCount(1)
+                .article(article)
+                .build();
+
+        given(articleRepository.findById(1L)).willReturn(Optional.of(article));
+        given(reportArticleRepository.findByArticle(article)).willReturn(Optional.empty());
+        given(reportArticleRepository.save(any())).willReturn(reportArticle);
+
+        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
+
+        // When
+        boolean result = reportArticleService.createReportArticle(new SubmitReportRequest("ARTICLE", 1L, "INSULT", "test memo"));
+
+        // Then
+        verify(reportArticleRepository).findByArticle(any());
+        verify(reportArticleRepository).save(any());
+        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
+        assertTrue(result);
+        assertEquals(reportArticle, reportRecordArgumentCaptor.getValue().getReport());
+
     }
 
     @Test
-    void deleteReportArticle() {
+    @DisplayName("신고 등록 API 서비스 테스트 성공 - 게시글 신고 (기존 게시글에 신고내역이 있을때)")
+    void createReportArticle_ArticleAlreadyReportedBefore() {
+
         //given
+        Article article = Article.builder()
+                .id(1L)
+                .title("test")
+                .content("테스트용")
+                .author("test")
+                .password("1234")
+                .registeredAt(LocalDateTime.now())
+                .build();
+
+        ReportArticle reportArticle = ReportArticle.builder()
+                .id(1L)
+                .firstReportedAt(LocalDateTime.now())
+                .contentType("ARTICLE")
+                .reportedCount(1)
+                .article(article)
+                .build();
+
+        given(articleRepository.findById(1L)).willReturn(Optional.of(article));
+        given(reportArticleRepository.findByArticle(article)).willReturn(Optional.of(reportArticle));
+
+        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
+
+        // When
+        boolean result = reportArticleService.createReportArticle(new SubmitReportRequest("ARTICLE", 1L, "INSULT", "test memo"));
+
+        // Then
+        verify(reportArticleRepository).findByArticle(any());
+        verify(reportArticleRepository, never()).save(any());
+        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
+        assertTrue(result);
+        assertEquals(reportArticle, reportRecordArgumentCaptor.getValue().getReport());
+
+    }
+
+    @Test
+    @DisplayName("신고 삭제 API 서비스 테스트 성공 - 게시글 신고")
+    void deleteReportArticle() {
+
+        //given
+        Article article = Article.builder()
+                .id(1L)
+                .title("test")
+                .content("테스트용")
+                .author("test")
+                .password("1234")
+                .registeredAt(LocalDateTime.now())
+                .build();
+
+        ReportArticle reportArticle = ReportArticle.builder()
+                .id(1L)
+                .firstReportedAt(LocalDateTime.now())
+                .contentType("ARTICLE")
+                .reportedCount(1)
+                .article(article)
+                .build();
+
+
         //when
+        boolean result = reportArticleService.deleteReportArticle(reportArticle);
+
         //then
+        verify(articleRepository).delete(article);
+        verify(reportArticleRepository).delete(reportArticle);
+        assertTrue(result);
+
     }
 }

--- a/src/test/java/com/example/unknowngserver/report/service/ReportArticleServiceTest.java
+++ b/src/test/java/com/example/unknowngserver/report/service/ReportArticleServiceTest.java
@@ -1,187 +1,29 @@
 package com.example.unknowngserver.report.service;
 
-import com.example.unknowngserver.article.entity.Article;
-import com.example.unknowngserver.article.repository.ArticleRepository;
-import com.example.unknowngserver.report.dto.ReportDetailDto;
-import com.example.unknowngserver.report.dto.SubmitReportRequest;
-import com.example.unknowngserver.report.entity.ReportArticle;
-import com.example.unknowngserver.report.entity.ReportRecord;
-import com.example.unknowngserver.report.repository.ReportArticleRepository;
-import com.example.unknowngserver.report.repository.ReportRecordRepository;
-
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
-@ExtendWith(MockitoExtension.class)
 class ReportArticleServiceTest {
 
-    @Mock
-    private ReportArticleRepository reportArticleRepository;
-    @Mock
-    private ReportRecordRepository reportRecordRepository;
-    @Mock
-    private ArticleRepository articleRepository;
-
-    @InjectMocks
-    private ReportArticleService reportArticleService;
-
     @Test
-    @DisplayName("신고 상세 내용 조회 API 서비스 테스트 성공 - 게시글 신고")
     void getReportArticleDetail() {
-
         //given
-        Article article = Article.builder()
-                .id(1L)
-                .title("test")
-                .content("테스트용")
-                .author("test")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
-
-        ReportArticle reportArticle = ReportArticle.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("ARTICLE")
-                .reportedCount(1)
-                .article(article)
-                .build();
-
         //when
-        ReportDetailDto reportDetailDto = reportArticleService.getReportArticleDetail(reportArticle);
-
         //then
-        assertEquals(1L, reportDetailDto.getReportId());
-        assertEquals("ARTICLE", reportDetailDto.getReportedContentType());
-        assertEquals(1, reportDetailDto.getReportedCount());
-        assertEquals(1L, reportDetailDto.getTargetId());
-        assertEquals("테스트용", reportDetailDto.getTargetContent());
-
     }
 
     @Test
-    @DisplayName("신고 등록 API 서비스 테스트 성공 - 게시글 신고 (기존 게시글에 신고내역이 없을때)")
     void createReportArticle() {
-
         //given
-        Article article = Article.builder()
-                .id(1L)
-                .title("test")
-                .content("테스트용")
-                .author("test")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
-
-        ReportArticle reportArticle = ReportArticle.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("ARTICLE")
-                .reportedCount(1)
-                .article(article)
-                .build();
-
-        given(articleRepository.findById(1L)).willReturn(Optional.of(article));
-        given(reportArticleRepository.findByArticle(article)).willReturn(Optional.empty());
-        given(reportArticleRepository.save(any())).willReturn(reportArticle);
-
-        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
-
-        // When
-        boolean result = reportArticleService.createReportArticle(new SubmitReportRequest("ARTICLE", 1L, "INSULT", "test memo"));
-
-        // Then
-        verify(reportArticleRepository).findByArticle(any());
-        verify(reportArticleRepository).save(any());
-        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
-        assertTrue(result);
-        assertEquals(reportArticle, reportRecordArgumentCaptor.getValue().getReport());
-
-    }
-
-    @Test
-    @DisplayName("신고 등록 API 서비스 테스트 성공 - 게시글 신고 (기존 게시글에 신고내역이 있을때)")
-    void createReportArticle_ArticleAlreadyReportedBefore() {
-
-        //given
-        Article article = Article.builder()
-                .id(1L)
-                .title("test")
-                .content("테스트용")
-                .author("test")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
-
-        ReportArticle reportArticle = ReportArticle.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("ARTICLE")
-                .reportedCount(1)
-                .article(article)
-                .build();
-
-        given(articleRepository.findById(1L)).willReturn(Optional.of(article));
-        given(reportArticleRepository.findByArticle(article)).willReturn(Optional.of(reportArticle));
-
-        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
-
-        // When
-        boolean result = reportArticleService.createReportArticle(new SubmitReportRequest("ARTICLE", 1L, "INSULT", "test memo"));
-
-        // Then
-        verify(reportArticleRepository).findByArticle(any());
-        verify(reportArticleRepository, never()).save(any());
-        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
-        assertTrue(result);
-        assertEquals(reportArticle, reportRecordArgumentCaptor.getValue().getReport());
-
-    }
-
-    @Test
-    @DisplayName("신고 삭제 API 서비스 테스트 성공 - 게시글 신고")
-    void deleteReportArticle() {
-
-        //given
-        Article article = Article.builder()
-                .id(1L)
-                .title("test")
-                .content("테스트용")
-                .author("test")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
-
-        ReportArticle reportArticle = ReportArticle.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("ARTICLE")
-                .reportedCount(1)
-                .article(article)
-                .build();
-
-
         //when
-        boolean result = reportArticleService.deleteReportArticle(reportArticle);
-
         //then
-        verify(articleRepository).delete(article);
-        verify(reportArticleRepository).delete(reportArticle);
-        assertTrue(result);
+    }
 
+    @Test
+    void deleteReportArticle() {
+        //given
+        //when
+        //then
     }
 }

--- a/src/test/java/com/example/unknowngserver/report/service/ReportArticleServiceTest.java
+++ b/src/test/java/com/example/unknowngserver/report/service/ReportArticleServiceTest.java
@@ -30,158 +30,158 @@ import static org.mockito.Mockito.verify;
 class ReportArticleServiceTest {
 
     @Mock
-    private ReportArticleRepository reportArticleRepository;
+    private ReportArticleRepository reportArticleRepository; 
     @Mock
-    private ReportRecordRepository reportRecordRepository;
+    private ReportRecordRepository reportRecordRepository; 
     @Mock
-    private ArticleRepository articleRepository;
+    private ArticleRepository articleRepository; 
 
     @InjectMocks
-    private ReportArticleService reportArticleService;
+    private ReportArticleService reportArticleService; 
 
     @Test
-    @DisplayName("신고 상세 내용 조회 API 서비스 테스트 성공 - 게시글 신고")
-    void getReportArticleDetail() {
+    @DisplayName("신고 상세 내용 조회 API 서비스 테스트 성공 - 게시글 신고") 
+    void getReportArticleDetail() { 
 
         //given
-        Article article = Article.builder()
-                .id(1L)
-                .title("test")
-                .content("테스트용")
-                .author("test")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
+        Article article = Article.builder() 
+                .id(1L) 
+                .title("test") 
+                .content("테스트용") 
+                .author("test") 
+                .password("1234") 
+                .registeredAt(LocalDateTime.now()) 
+                .build(); 
 
-        ReportArticle reportArticle = ReportArticle.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("ARTICLE")
-                .reportedCount(1)
-                .article(article)
-                .build();
+        ReportArticle reportArticle = ReportArticle.builder() 
+                .id(1L) 
+                .firstReportedAt(LocalDateTime.now()) 
+                .contentType("ARTICLE") 
+                .reportedCount(1) 
+                .article(article) 
+                .build(); 
 
         //when
-        ReportDetailDto reportDetailDto = reportArticleService.getReportArticleDetail(reportArticle);
+        ReportDetailDto reportDetailDto = reportArticleService.getReportArticleDetail(reportArticle); 
 
         //then
-        assertEquals(1L, reportDetailDto.getReportId());
-        assertEquals("ARTICLE", reportDetailDto.getReportedContentType());
-        assertEquals(1, reportDetailDto.getReportedCount());
-        assertEquals(1L, reportDetailDto.getTargetId());
-        assertEquals("테스트용", reportDetailDto.getTargetContent());
+        assertEquals(1L, reportDetailDto.getReportId()); 
+        assertEquals("ARTICLE", reportDetailDto.getReportedContentType()); 
+        assertEquals(1, reportDetailDto.getReportedCount()); 
+        assertEquals(1L, reportDetailDto.getTargetId()); 
+        assertEquals("테스트용", reportDetailDto.getTargetContent()); 
 
-    }
-
+    } 
+ 
     @Test
-    @DisplayName("신고 등록 API 서비스 테스트 성공 - 게시글 신고 (기존 게시글에 신고내역이 없을때)")
-    void createReportArticle() {
-
+    @DisplayName("신고 등록 API 서비스 테스트 성공 - 게시글 신고 (기존 게시글에 신고내역이 없을때)") 
+    void createReportArticle() { 
+ 
         //given
-        Article article = Article.builder()
-                .id(1L)
-                .title("test")
-                .content("테스트용")
-                .author("test")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
+        Article article = Article.builder() 
+                .id(1L) 
+                .title("test") 
+                .content("테스트용") 
+                .author("test") 
+                .password("1234") 
+                .registeredAt(LocalDateTime.now()) 
+                .build(); 
 
-        ReportArticle reportArticle = ReportArticle.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("ARTICLE")
-                .reportedCount(1)
-                .article(article)
-                .build();
+        ReportArticle reportArticle = ReportArticle.builder() 
+                .id(1L) 
+                .firstReportedAt(LocalDateTime.now()) 
+                .contentType("ARTICLE") 
+                .reportedCount(1) 
+                .article(article) 
+                .build(); 
 
-        given(articleRepository.findById(1L)).willReturn(Optional.of(article));
-        given(reportArticleRepository.findByArticle(article)).willReturn(Optional.empty());
-        given(reportArticleRepository.save(any())).willReturn(reportArticle);
+        given(articleRepository.findById(1L)).willReturn(Optional.of(article)); 
+        given(reportArticleRepository.findByArticle(article)).willReturn(Optional.empty()); 
+        given(reportArticleRepository.save(any())).willReturn(reportArticle); 
 
-        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
+        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class); 
 
         // When
-        boolean result = reportArticleService.createReportArticle(new SubmitReportRequest("ARTICLE", 1L, "INSULT", "test memo"));
+        boolean result = reportArticleService.createReportArticle(new SubmitReportRequest("ARTICLE", 1L, "INSULT", "test memo")); 
 
         // Then
-        verify(reportArticleRepository).findByArticle(any());
-        verify(reportArticleRepository).save(any());
-        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
-        assertTrue(result);
-        assertEquals(reportArticle, reportRecordArgumentCaptor.getValue().getReport());
+        verify(reportArticleRepository).findByArticle(any()); 
+        verify(reportArticleRepository).save(any()); 
+        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture()); 
+        assertTrue(result); 
+        assertEquals(reportArticle, reportRecordArgumentCaptor.getValue().getReport()); 
 
     }
 
     @Test
-    @DisplayName("신고 등록 API 서비스 테스트 성공 - 게시글 신고 (기존 게시글에 신고내역이 있을때)")
-    void createReportArticle_ArticleAlreadyReportedBefore() {
-
+    @DisplayName("신고 등록 API 서비스 테스트 성공 - 게시글 신고 (기존 게시글에 신고내역이 있을때)") 
+    void createReportArticle_ArticleAlreadyReportedBefore() { 
+ 
         //given
-        Article article = Article.builder()
-                .id(1L)
-                .title("test")
-                .content("테스트용")
-                .author("test")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
+        Article article = Article.builder() 
+                .id(1L) 
+                .title("test") 
+                .content("테스트용") 
+                .author("test") 
+                .password("1234") 
+                .registeredAt(LocalDateTime.now()) 
+                .build(); 
 
-        ReportArticle reportArticle = ReportArticle.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("ARTICLE")
-                .reportedCount(1)
-                .article(article)
-                .build();
+        ReportArticle reportArticle = ReportArticle.builder() 
+                .id(1L) 
+                .firstReportedAt(LocalDateTime.now()) 
+                .contentType("ARTICLE") 
+                .reportedCount(1) 
+                .article(article) 
+                .build(); 
 
-        given(articleRepository.findById(1L)).willReturn(Optional.of(article));
-        given(reportArticleRepository.findByArticle(article)).willReturn(Optional.of(reportArticle));
+        given(articleRepository.findById(1L)).willReturn(Optional.of(article)); 
+        given(reportArticleRepository.findByArticle(article)).willReturn(Optional.of(reportArticle)); 
 
-        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
-
+        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class); 
+ 
         // When
-        boolean result = reportArticleService.createReportArticle(new SubmitReportRequest("ARTICLE", 1L, "INSULT", "test memo"));
+        boolean result = reportArticleService.createReportArticle(new SubmitReportRequest("ARTICLE", 1L, "INSULT", "test memo")); 
+ 
+        // Then 
+        verify(reportArticleRepository).findByArticle(any()); 
+        verify(reportArticleRepository, never()).save(any()); 
+        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture()); 
+        assertTrue(result); 
+        assertEquals(reportArticle, reportRecordArgumentCaptor.getValue().getReport()); 
 
-        // Then
-        verify(reportArticleRepository).findByArticle(any());
-        verify(reportArticleRepository, never()).save(any());
-        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
-        assertTrue(result);
-        assertEquals(reportArticle, reportRecordArgumentCaptor.getValue().getReport());
+    } 
 
-    }
-
-    @Test
-    @DisplayName("신고 삭제 API 서비스 테스트 성공 - 게시글 신고")
-    void deleteReportArticle() {
+    @Test 
+    @DisplayName("신고 삭제 API 서비스 테스트 성공 - 게시글 신고") 
+    void deleteReportArticle() { 
 
         //given
-        Article article = Article.builder()
-                .id(1L)
-                .title("test")
-                .content("테스트용")
-                .author("test")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
+        Article article = Article.builder() 
+                .id(1L) 
+                .title("test") 
+                .content("테스트용") 
+                .author("test") 
+                .password("1234") 
+                .registeredAt(LocalDateTime.now()) 
+                .build(); 
 
-        ReportArticle reportArticle = ReportArticle.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("ARTICLE")
-                .reportedCount(1)
-                .article(article)
-                .build();
-
+        ReportArticle reportArticle = ReportArticle.builder() 
+                .id(1L) 
+                .firstReportedAt(LocalDateTime.now()) 
+                .contentType("ARTICLE") 
+                .reportedCount(1) 
+                .article(article) 
+                .build(); 
+ 
 
         //when
-        boolean result = reportArticleService.deleteReportArticle(reportArticle);
+        boolean result = reportArticleService.deleteReportArticle(reportArticle); 
 
-        //then
-        verify(articleRepository).delete(article);
-        verify(reportArticleRepository).delete(reportArticle);
-        assertTrue(result);
+        //then 
+        verify(articleRepository).delete(article); 
+        verify(reportArticleRepository).delete(reportArticle); 
+        assertTrue(result); 
 
-    }
-}
+    } 
+} 

--- a/src/test/java/com/example/unknowngserver/report/service/ReportCommentServiceTest.java
+++ b/src/test/java/com/example/unknowngserver/report/service/ReportCommentServiceTest.java
@@ -1,183 +1,29 @@
 package com.example.unknowngserver.report.service;
 
-import com.example.unknowngserver.article.entity.Article;
-import com.example.unknowngserver.comment.entity.Comment;
-import com.example.unknowngserver.comment.repository.CommentRepository;
-import com.example.unknowngserver.report.dto.ReportDetailDto;
-import com.example.unknowngserver.report.dto.SubmitReportRequest;
-import com.example.unknowngserver.report.entity.Report;
-import com.example.unknowngserver.report.entity.ReportComment;
-import com.example.unknowngserver.report.entity.ReportRecord;
-import com.example.unknowngserver.report.repository.ReportCommentRepository;
-import com.example.unknowngserver.report.repository.ReportRecordRepository;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
-@ExtendWith(MockitoExtension.class)
 class ReportCommentServiceTest {
 
-    @Mock
-    private ReportCommentRepository reportCommentRepository;
-    @Mock
-    private ReportRecordRepository reportRecordRepository;
-    @Mock
-    private CommentRepository commentRepository;
-
-    @InjectMocks
-    private ReportCommentService reportCommentService;
-
     @Test
-    @DisplayName("신고 상세 내용 조회 API 서비스 테스트 성공 - 댓글 신고")
     void getReportCommentDetail() {
-
         //given
-        Comment comment1 = Comment.builder()
-                .id(1L)
-                .content("comment test 1")
-                .author("ctest1")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
-
-        ReportComment report = ReportComment.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("COMMENT")
-                .reportedCount(1)
-                .comment(comment1)
-                .build();
-
         //when
-        ReportDetailDto reportDetailDto = reportCommentService.getReportCommentDetail(report);
-
         //then
-        assertEquals(1L, reportDetailDto.getReportId());
-        assertEquals("COMMENT", reportDetailDto.getReportedContentType());
-        assertEquals(1, reportDetailDto.getReportedCount());
-        assertEquals(1L, reportDetailDto.getTargetId());
-        assertEquals("comment test 1", reportDetailDto.getTargetContent());
-
     }
 
     @Test
-    @DisplayName("신고 등록 API 서비스 테스트 성공 - 댓글 신고 (기존 댓글에 신고내역이 없을때)")
     void createReportComment() {
-
         //given
-        Comment comment1 = Comment.builder()
-                .id(1L)
-                .content("comment test 1")
-                .author("ctest1")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
-
-        ReportComment report = ReportComment.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("COMMENT")
-                .reportedCount(1)
-                .comment(comment1)
-                .build();
-
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment1));
-        given(reportCommentRepository.findByComment(comment1)).willReturn(Optional.empty());
-        given(reportCommentRepository.save(any())).willReturn(report);
-
-        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
-
         //when
-        boolean result = reportCommentService.createReportComment(new SubmitReportRequest("COMMET", 1L, "INSULT", "test memo"));
-
         //then
-        verify(reportCommentRepository).findByComment(any());
-        verify(reportCommentRepository).save(any());
-        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
-        assertTrue(result);
-        assertEquals(report, reportRecordArgumentCaptor.getValue().getReport());
-
     }
 
     @Test
-    @DisplayName("신고 등록 API 서비스 테스트 성공 - 댓글 신고 (기존 댓글에 신고내역이 없을때)")
-    void createReportComment_CommentAlreadyReportedBefore() {
-
-        //given
-        Comment comment1 = Comment.builder()
-                .id(1L)
-                .content("comment test 1")
-                .author("ctest1")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
-
-        ReportComment report = ReportComment.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("COMMENT")
-                .reportedCount(1)
-                .comment(comment1)
-                .build();
-
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment1));
-        given(reportCommentRepository.findByComment(comment1)).willReturn(Optional.of(report));
-
-        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
-
-        //when
-        boolean result = reportCommentService.createReportComment(new SubmitReportRequest("COMMET", 1L, "INSULT", "test memo"));
-
-        //then
-        verify(reportCommentRepository).findByComment(any());
-        verify(reportCommentRepository, never()).save(any());
-        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
-        assertTrue(result);
-        assertEquals(report, reportRecordArgumentCaptor.getValue().getReport());
-
-    }
-
-    @Test
-    @DisplayName("신고 삭제 API 서비스 테스트 성공 - 댓글 신고")
     void deleteReportComment() {
-
         //given
-        Comment comment1 = Comment.builder()
-                .id(1L)
-                .content("comment test 1")
-                .author("ctest1")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
-
-        ReportComment report = ReportComment.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("COMMENT")
-                .reportedCount(1)
-                .comment(comment1)
-                .build();
-
         //when
-        boolean result = reportCommentService.deleteReportComment(report);
-
         //then
-        verify(commentRepository).delete(comment1);
-        verify(reportCommentRepository).delete(report);
-        assertTrue(result);
-
     }
 }

--- a/src/test/java/com/example/unknowngserver/report/service/ReportCommentServiceTest.java
+++ b/src/test/java/com/example/unknowngserver/report/service/ReportCommentServiceTest.java
@@ -27,157 +27,157 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(MockitoExtension.class)
-class ReportCommentServiceTest {
+@ExtendWith(MockitoExtension.class) 
+class ReportCommentServiceTest { 
 
-    @Mock
-    private ReportCommentRepository reportCommentRepository;
-    @Mock
-    private ReportRecordRepository reportRecordRepository;
-    @Mock
-    private CommentRepository commentRepository;
+    @Mock 
+    private ReportCommentRepository reportCommentRepository; 
+    @Mock 
+    private ReportRecordRepository reportRecordRepository; 
+    @Mock 
+    private CommentRepository commentRepository; 
 
-    @InjectMocks
-    private ReportCommentService reportCommentService;
+    @InjectMocks 
+    private ReportCommentService reportCommentService; 
 
-    @Test
-    @DisplayName("신고 상세 내용 조회 API 서비스 테스트 성공 - 댓글 신고")
-    void getReportCommentDetail() {
+    @Test 
+    @DisplayName("신고 상세 내용 조회 API 서비스 테스트 성공 - 댓글 신고") 
+    void getReportCommentDetail() { 
 
         //given
-        Comment comment1 = Comment.builder()
-                .id(1L)
-                .content("comment test 1")
-                .author("ctest1")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
+        Comment comment1 = Comment.builder() 
+                .id(1L) 
+                .content("comment test 1") 
+                .author("ctest1") 
+                .password("1234") 
+                .registeredAt(LocalDateTime.now()) 
+                .build(); 
 
-        ReportComment report = ReportComment.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("COMMENT")
-                .reportedCount(1)
-                .comment(comment1)
-                .build();
+        ReportComment report = ReportComment.builder() 
+                .id(1L) 
+                .firstReportedAt(LocalDateTime.now()) 
+                .contentType("COMMENT") 
+                .reportedCount(1) 
+                .comment(comment1) 
+                .build(); 
 
         //when
-        ReportDetailDto reportDetailDto = reportCommentService.getReportCommentDetail(report);
+        ReportDetailDto reportDetailDto = reportCommentService.getReportCommentDetail(report); 
+ 
+        //then
+        assertEquals(1L, reportDetailDto.getReportId()); 
+        assertEquals("COMMENT", reportDetailDto.getReportedContentType()); 
+        assertEquals(1, reportDetailDto.getReportedCount()); 
+        assertEquals(1L, reportDetailDto.getTargetId()); 
+        assertEquals("comment test 1", reportDetailDto.getTargetContent()); 
+
+    } 
+
+    @Test 
+    @DisplayName("신고 등록 API 서비스 테스트 성공 - 댓글 신고 (기존 댓글에 신고내역이 없을때)") 
+    void createReportComment() { 
+
+        //given
+        Comment comment1 = Comment.builder() 
+                .id(1L) 
+                .content("comment test 1") 
+                .author("ctest1") 
+                .password("1234") 
+                .registeredAt(LocalDateTime.now()) 
+                .build(); 
+
+        ReportComment report = ReportComment.builder() 
+                .id(1L) 
+                .firstReportedAt(LocalDateTime.now()) 
+                .contentType("COMMENT") 
+                .reportedCount(1) 
+                .comment(comment1) 
+                .build(); 
+
+        given(commentRepository.findById(1L)).willReturn(Optional.of(comment1)); 
+        given(reportCommentRepository.findByComment(comment1)).willReturn(Optional.empty()); 
+        given(reportCommentRepository.save(any())).willReturn(report); 
+
+        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class); 
+
+        //when
+        boolean result = reportCommentService.createReportComment(new SubmitReportRequest("COMMET", 1L, "INSULT", "test memo")); 
 
         //then
-        assertEquals(1L, reportDetailDto.getReportId());
-        assertEquals("COMMENT", reportDetailDto.getReportedContentType());
-        assertEquals(1, reportDetailDto.getReportedCount());
-        assertEquals(1L, reportDetailDto.getTargetId());
-        assertEquals("comment test 1", reportDetailDto.getTargetContent());
+        verify(reportCommentRepository).findByComment(any()); 
+        verify(reportCommentRepository).save(any());  
+        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture()); 
+        assertTrue(result); 
+        assertEquals(report, reportRecordArgumentCaptor.getValue().getReport()); 
 
     }
 
-    @Test
-    @DisplayName("신고 등록 API 서비스 테스트 성공 - 댓글 신고 (기존 댓글에 신고내역이 없을때)")
-    void createReportComment() {
-
+    @Test 
+    @DisplayName("신고 등록 API 서비스 테스트 성공 - 댓글 신고 (기존 댓글에 신고내역이 없을때)") 
+    void createReportComment_CommentAlreadyReportedBefore() { 
+ 
         //given
-        Comment comment1 = Comment.builder()
-                .id(1L)
-                .content("comment test 1")
-                .author("ctest1")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
+        Comment comment1 = Comment.builder() 
+                .id(1L) 
+                .content("comment test 1") 
+                .author("ctest1") 
+                .password("1234") 
+                .registeredAt(LocalDateTime.now()) 
+                .build(); 
 
-        ReportComment report = ReportComment.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("COMMENT")
-                .reportedCount(1)
-                .comment(comment1)
-                .build();
+        ReportComment report = ReportComment.builder() 
+                .id(1L) 
+                .firstReportedAt(LocalDateTime.now()) 
+                .contentType("COMMENT") 
+                .reportedCount(1) 
+                .comment(comment1) 
+                .build(); 
 
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment1));
-        given(reportCommentRepository.findByComment(comment1)).willReturn(Optional.empty());
-        given(reportCommentRepository.save(any())).willReturn(report);
+        given(commentRepository.findById(1L)).willReturn(Optional.of(comment1)); 
+        given(reportCommentRepository.findByComment(comment1)).willReturn(Optional.of(report)); 
 
-        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
+        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class); 
 
         //when
-        boolean result = reportCommentService.createReportComment(new SubmitReportRequest("COMMET", 1L, "INSULT", "test memo"));
+        boolean result = reportCommentService.createReportComment(new SubmitReportRequest("COMMET", 1L, "INSULT", "test memo")); 
 
         //then
-        verify(reportCommentRepository).findByComment(any());
-        verify(reportCommentRepository).save(any());
-        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
-        assertTrue(result);
-        assertEquals(report, reportRecordArgumentCaptor.getValue().getReport());
+        verify(reportCommentRepository).findByComment(any()); 
+        verify(reportCommentRepository, never()).save(any()); 
+        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture()); 
+        assertTrue(result); 
+        assertEquals(report, reportRecordArgumentCaptor.getValue().getReport()); 
+ 
+    } 
 
-    }
-
-    @Test
-    @DisplayName("신고 등록 API 서비스 테스트 성공 - 댓글 신고 (기존 댓글에 신고내역이 없을때)")
-    void createReportComment_CommentAlreadyReportedBefore() {
+    @Test 
+    @DisplayName("신고 삭제 API 서비스 테스트 성공 - 댓글 신고") 
+    void deleteReportComment() { 
 
         //given
-        Comment comment1 = Comment.builder()
-                .id(1L)
-                .content("comment test 1")
-                .author("ctest1")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
+        Comment comment1 = Comment.builder() 
+                .id(1L) 
+                .content("comment test 1") 
+                .author("ctest1") 
+                .password("1234") 
+                .registeredAt(LocalDateTime.now()) 
+                .build(); 
 
-        ReportComment report = ReportComment.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("COMMENT")
-                .reportedCount(1)
-                .comment(comment1)
-                .build();
-
-        given(commentRepository.findById(1L)).willReturn(Optional.of(comment1));
-        given(reportCommentRepository.findByComment(comment1)).willReturn(Optional.of(report));
-
-        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
+        ReportComment report = ReportComment.builder() 
+                .id(1L) 
+                .firstReportedAt(LocalDateTime.now()) 
+                .contentType("COMMENT") 
+                .reportedCount(1) 
+                .comment(comment1) 
+                .build(); 
 
         //when
-        boolean result = reportCommentService.createReportComment(new SubmitReportRequest("COMMET", 1L, "INSULT", "test memo"));
+        boolean result = reportCommentService.deleteReportComment(report); 
 
         //then
-        verify(reportCommentRepository).findByComment(any());
-        verify(reportCommentRepository, never()).save(any());
-        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
-        assertTrue(result);
-        assertEquals(report, reportRecordArgumentCaptor.getValue().getReport());
+        verify(commentRepository).delete(comment1); 
+        verify(reportCommentRepository).delete(report); 
+        assertTrue(result); 
 
-    }
-
-    @Test
-    @DisplayName("신고 삭제 API 서비스 테스트 성공 - 댓글 신고")
-    void deleteReportComment() {
-
-        //given
-        Comment comment1 = Comment.builder()
-                .id(1L)
-                .content("comment test 1")
-                .author("ctest1")
-                .password("1234")
-                .registeredAt(LocalDateTime.now())
-                .build();
-
-        ReportComment report = ReportComment.builder()
-                .id(1L)
-                .firstReportedAt(LocalDateTime.now())
-                .contentType("COMMENT")
-                .reportedCount(1)
-                .comment(comment1)
-                .build();
-
-        //when
-        boolean result = reportCommentService.deleteReportComment(report);
-
-        //then
-        verify(commentRepository).delete(comment1);
-        verify(reportCommentRepository).delete(report);
-        assertTrue(result);
-
-    }
-}
+    } 
+} 

--- a/src/test/java/com/example/unknowngserver/report/service/ReportCommentServiceTest.java
+++ b/src/test/java/com/example/unknowngserver/report/service/ReportCommentServiceTest.java
@@ -1,29 +1,183 @@
 package com.example.unknowngserver.report.service;
 
+import com.example.unknowngserver.article.entity.Article;
+import com.example.unknowngserver.comment.entity.Comment;
+import com.example.unknowngserver.comment.repository.CommentRepository;
+import com.example.unknowngserver.report.dto.ReportDetailDto;
+import com.example.unknowngserver.report.dto.SubmitReportRequest;
+import com.example.unknowngserver.report.entity.Report;
+import com.example.unknowngserver.report.entity.ReportComment;
+import com.example.unknowngserver.report.entity.ReportRecord;
+import com.example.unknowngserver.report.repository.ReportCommentRepository;
+import com.example.unknowngserver.report.repository.ReportRecordRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class ReportCommentServiceTest {
 
+    @Mock
+    private ReportCommentRepository reportCommentRepository;
+    @Mock
+    private ReportRecordRepository reportRecordRepository;
+    @Mock
+    private CommentRepository commentRepository;
+
+    @InjectMocks
+    private ReportCommentService reportCommentService;
+
     @Test
+    @DisplayName("신고 상세 내용 조회 API 서비스 테스트 성공 - 댓글 신고")
     void getReportCommentDetail() {
+
         //given
+        Comment comment1 = Comment.builder()
+                .id(1L)
+                .content("comment test 1")
+                .author("ctest1")
+                .password("1234")
+                .registeredAt(LocalDateTime.now())
+                .build();
+
+        ReportComment report = ReportComment.builder()
+                .id(1L)
+                .firstReportedAt(LocalDateTime.now())
+                .contentType("COMMENT")
+                .reportedCount(1)
+                .comment(comment1)
+                .build();
+
         //when
+        ReportDetailDto reportDetailDto = reportCommentService.getReportCommentDetail(report);
+
         //then
+        assertEquals(1L, reportDetailDto.getReportId());
+        assertEquals("COMMENT", reportDetailDto.getReportedContentType());
+        assertEquals(1, reportDetailDto.getReportedCount());
+        assertEquals(1L, reportDetailDto.getTargetId());
+        assertEquals("comment test 1", reportDetailDto.getTargetContent());
+
     }
 
     @Test
+    @DisplayName("신고 등록 API 서비스 테스트 성공 - 댓글 신고 (기존 댓글에 신고내역이 없을때)")
     void createReportComment() {
+
         //given
+        Comment comment1 = Comment.builder()
+                .id(1L)
+                .content("comment test 1")
+                .author("ctest1")
+                .password("1234")
+                .registeredAt(LocalDateTime.now())
+                .build();
+
+        ReportComment report = ReportComment.builder()
+                .id(1L)
+                .firstReportedAt(LocalDateTime.now())
+                .contentType("COMMENT")
+                .reportedCount(1)
+                .comment(comment1)
+                .build();
+
+        given(commentRepository.findById(1L)).willReturn(Optional.of(comment1));
+        given(reportCommentRepository.findByComment(comment1)).willReturn(Optional.empty());
+        given(reportCommentRepository.save(any())).willReturn(report);
+
+        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
+
         //when
+        boolean result = reportCommentService.createReportComment(new SubmitReportRequest("COMMET", 1L, "INSULT", "test memo"));
+
         //then
+        verify(reportCommentRepository).findByComment(any());
+        verify(reportCommentRepository).save(any());
+        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
+        assertTrue(result);
+        assertEquals(report, reportRecordArgumentCaptor.getValue().getReport());
+
     }
 
     @Test
-    void deleteReportComment() {
+    @DisplayName("신고 등록 API 서비스 테스트 성공 - 댓글 신고 (기존 댓글에 신고내역이 없을때)")
+    void createReportComment_CommentAlreadyReportedBefore() {
+
         //given
+        Comment comment1 = Comment.builder()
+                .id(1L)
+                .content("comment test 1")
+                .author("ctest1")
+                .password("1234")
+                .registeredAt(LocalDateTime.now())
+                .build();
+
+        ReportComment report = ReportComment.builder()
+                .id(1L)
+                .firstReportedAt(LocalDateTime.now())
+                .contentType("COMMENT")
+                .reportedCount(1)
+                .comment(comment1)
+                .build();
+
+        given(commentRepository.findById(1L)).willReturn(Optional.of(comment1));
+        given(reportCommentRepository.findByComment(comment1)).willReturn(Optional.of(report));
+
+        ArgumentCaptor<ReportRecord> reportRecordArgumentCaptor = ArgumentCaptor.forClass(ReportRecord.class);
+
         //when
+        boolean result = reportCommentService.createReportComment(new SubmitReportRequest("COMMET", 1L, "INSULT", "test memo"));
+
         //then
+        verify(reportCommentRepository).findByComment(any());
+        verify(reportCommentRepository, never()).save(any());
+        verify(reportRecordRepository).save(reportRecordArgumentCaptor.capture());
+        assertTrue(result);
+        assertEquals(report, reportRecordArgumentCaptor.getValue().getReport());
+
+    }
+
+    @Test
+    @DisplayName("신고 삭제 API 서비스 테스트 성공 - 댓글 신고")
+    void deleteReportComment() {
+
+        //given
+        Comment comment1 = Comment.builder()
+                .id(1L)
+                .content("comment test 1")
+                .author("ctest1")
+                .password("1234")
+                .registeredAt(LocalDateTime.now())
+                .build();
+
+        ReportComment report = ReportComment.builder()
+                .id(1L)
+                .firstReportedAt(LocalDateTime.now())
+                .contentType("COMMENT")
+                .reportedCount(1)
+                .comment(comment1)
+                .build();
+
+        //when
+        boolean result = reportCommentService.deleteReportComment(report);
+
+        //then
+        verify(commentRepository).delete(comment1);
+        verify(reportCommentRepository).delete(report);
+        assertTrue(result);
+
     }
 }


### PR DESCRIPTION
## 개요
- 신고 서비스 레이어의 하위 서비스에 대한 테스트 코드 작성 및 신고 관련 api 에러 수정

## 타입
- test : 게시글신고서비스 테스트 코드 작성
- test : 댓글신고서비스 테스트 코드 작성
- fix : 테스트로 발견한 에러사항 수정
- refactor : 신고 서비스 코드 부분 리펙토링

## 작업 사항
- 신고 관련 엔티티들의 soft delete SQL 문에서 잘못된 변수를 수정하는 문제 해결
- 게시글과 댓글의 신고내역을 조회 한후, 신고내역이 없다면 새 신고내역을 생성하는 로직에서 발생하는 에러를 해결
- 신고 조회시 신고 횟수를 기준으로 내림차순 조회 하도록 수정
- 각 Content Type 에 맞는 ReportDetailDto 객체를 리턴하는 로직을 ReportDetailDto 객체에서 신고 서비스 레이어의 하위서비스로 옮김
- 사용하지 않는 코드 정리